### PR TITLE
Sundisk more responsive to color of light

### DIFF
--- a/Sources/VRage.Render11/Shaders/light_dir.hlsl
+++ b/Sources/VRage.Render11/Shaders/light_dir.hlsl
@@ -7,7 +7,7 @@ Texture2D<float> ShadowsMainView : register(MERGE(t, SHADOW_SLOT));
 
 float3 GetSunColor(float3 L, float3 V, float3 color, float sizeMult)
 {
-    return (color + 0.5f + float3(0.5f, 0.35f, 0.0f)) * pow(saturate(dot(L, -V)), 4000.0f) * sizeMult;
+    return color * 2 * pow(saturate(dot(L, -V)), 4000.0f) * sizeMult;
 }
 
 void __pixel_shader(PostprocessVertex vertex, out float3 output : SV_Target0


### PR DESCRIPTION
Sundisk is given more color corresponding to sunlight setting, instead
of being nearly all white. This should help environment mods as the sun
color will now match the color of light from the sun. Players not using
environment mods shouldn't notice a difference.
The result of this change is demonstrated on this image (original at
top, changed at bottom):
http://imageshack.com/a/img921/4418/2sox3F.jpg
